### PR TITLE
Add individual plan to autoread

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -56,7 +56,7 @@ class PlansController < ApplicationController
         notice = "User is now on your autoread list with priority level of #{params[:priority]}."
       end
     else
-      notice = "Could not change autoread priority. Please try again."
+      notice = "Could not change autoread priority. If this happens more than once, contact the Plans admins at grinnellplans@gmail.com."
     end
     redirect_to :back, notice: notice
   end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -49,6 +49,15 @@ class PlansController < ApplicationController
     interest = Account.find_by_username(params[:id])
     autofinger = owner.interests_in_others.find_or_create_by_interest(interest.id)
     success = autofinger.update_attributes(priority: params[:priority])
-    redirect_to :back
+    if success
+      if params[:priority] == '0'
+        notice = 'User was removed from your autoread list.'
+      else
+        notice = "User is now on your autoread list with priority level of #{params[:priority]}."
+      end
+    else
+      notice = "Could not change autoread priority. Please try again."
+    end
+    redirect_to :back, notice: notice
   end
 end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -43,4 +43,12 @@ class PlansController < ApplicationController
       # TODO
     end
   end
+
+  def set_autofinger_subscription
+    owner = current_account
+    interest = Account.find_by_username(params[:id])
+    autofinger = owner.interests_in_others.find_or_create_by_interest(interest.id)
+    success = autofinger.update_attributes(priority: params[:priority])
+    redirect_to :back
+  end
 end

--- a/app/models/autofinger.rb
+++ b/app/models/autofinger.rb
@@ -3,6 +3,7 @@ class Autofinger < ActiveRecord::Base
   self.primary_keys = :owner, :interest
   self.table_name = :autofinger
   validates_presence_of :owner, :interest, :priority
+  validates :priority, inclusion: { in: [0, 1, 2, 3] }
 
   belongs_to :interested_party, foreign_key: :owner, class_name: 'Account'
   belongs_to :subject_of_interest, foreign_key: :interest, class_name: 'Account'

--- a/app/models/autofinger.rb
+++ b/app/models/autofinger.rb
@@ -7,8 +7,6 @@ class Autofinger < ActiveRecord::Base
   belongs_to :interested_party, foreign_key: :owner, class_name: 'Account'
   belongs_to :subject_of_interest, foreign_key: :interest, class_name: 'Account'
 
-  validates_presence_of :interest, :owner
-
   scope :updated, where(updated: 1)
 
   def self.mark_plan_as_read(owner, interest)

--- a/app/views/account_sessions/new.haml
+++ b/app/views/account_sessions/new.haml
@@ -15,10 +15,6 @@
             =image_tag "logo.png"
         %tr.boxes
           %td.boxes{:colspan=>2, :align=>"center"}
-            - if flash[:notice]
-              %p.notice
-                = flash[:notice]
-
             =form_for @session, :url => account_session_path do |f|
               =f.label :"Username : "
               =f.text_field :username

--- a/app/views/accounts/new.haml
+++ b/app/views/accounts/new.haml
@@ -1,6 +1,3 @@
-- if flash[:notice]
-  %p.notice
-    = flash[:notice]
 %h1 Plan Registration
 %p
   If you have an email address at Grinnell College for yourself or for a group, you may use this page to create a Plan. Alumni are welcome to register with their alumni grinnell aliases. Please complete the form below to create your account. For any peculiar questions, please contact the administrators.

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -19,6 +19,9 @@
             =render :partial=>"/layouts/links"
             =render :partial => "/layouts/autofinger"
       .main
+        - if flash[:notice]
+          .notice
+            = flash[:notice]
         %div
           =yield
       =render :partial=>"/layouts/footer"

--- a/app/views/layouts/minimal.html.haml
+++ b/app/views/layouts/minimal.html.haml
@@ -11,6 +11,9 @@
   %body#planspage_readplan.plan
     #wrapper
       .main
+        - if flash[:notice]
+          .notice
+            = flash[:notice]
         %div
           =yield
       =render :partial=>"/layouts/footer"

--- a/app/views/password_resets/new.haml
+++ b/app/views/password_resets/new.haml
@@ -1,9 +1,5 @@
 %h1 Forgot Password
 
-- if flash[:notice]
-  %p.notice
-    = flash[:notice]
-
 %p Fill out the form below and instructions to reset your password will be emailed to you:
 
 =form_tag password_resets_path do

--- a/app/views/plans/show.html.haml
+++ b/app/views/plans/show.html.haml
@@ -31,3 +31,15 @@
 
 .plan_text
   =@account.plan.generated_html
+
+.autofinger-control
+  = form_tag set_autofinger_subscription_plan_path, method: :put do
+    = radio_button_tag :priority, 0
+    = label_tag 'priority_0', 'X'
+    = radio_button_tag :priority, 1
+    = label_tag 'priority_1', 1
+    = radio_button_tag :priority, 2
+    = label_tag 'priority_2', 2
+    = radio_button_tag :priority, 3
+    = label_tag 'priority_3', 3
+    = submit_tag 'Save'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Plans::Application.routes.draw do
+  # For more information on routing, see http://guides.rubyonrails.org/routing.html.
 
   # just remember to delete public/index.html.
   root controller: 'plans', action: 'show', id: 'plans'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,51 +1,5 @@
 Plans::Application.routes.draw do
 
-  # map.connect ':controller', :action => 'index'
-
-  # The priority is based upon order of creation:
-  # first created -> highest priority.
-
-  # Sample of regular route:
-  #   match 'products/:id' => 'catalog#view'
-  # Keep in mind you can assign values other than :controller and :action
-
-  # Sample of named route:
-  #   match 'products/:id/purchase' => 'catalog#purchase', :as => :purchase
-  # This route can be invoked with purchase_url(:id => product.id)
-
-  # Sample resource route (maps HTTP verbs to controller actions automatically):
-  #   resources :products
-
-  # Sample resource route with options:
-  #   resources :products do
-  #     member do
-  #       get 'short'
-  #       post 'toggle'
-  #     end
-  #
-  #     collection do
-  #       get 'sold'
-  #     end
-  #   end
-
-  # Sample resource route with sub-resources:
-  #   resources :products do
-  #     resources :comments, :sales
-  #     resource :seller
-  #   end
-
-  # Sample resource route with more complex sub-resources
-  #   resources :products do
-  #     resources :comments
-  #     resources :sales do
-  #       get 'recent', :on => :collection
-  #     end
-  #   end
-
-  # See how all your routes lay out with "rake routes"
-
-  # You can have the root of your site routed with "root"
-
   # just remember to delete public/index.html.
   root controller: 'plans', action: 'show', id: 'plans'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Plans::Application.routes.draw do
       put :update
       get :show, as: 'read'
       get :search
+      put :set_autofinger_subscription
     end
   end
 

--- a/spec/controllers/plans_controller_spec.rb
+++ b/spec/controllers/plans_controller_spec.rb
@@ -77,6 +77,9 @@ describe PlansController do
       it 'sets correct autoread priority' do
         expect(@account.interests_in_others.find_by_interest(interest.id).priority).to eq 1
       end
+      it 'sets correct flash message' do
+        expect(flash[:notice]).to eq 'User is now on your autoread list with priority level of 1.'
+      end
     end
 
     context 'logged in user changes priority of existing autoread subject' do
@@ -90,6 +93,26 @@ describe PlansController do
       end
       it "doesn't create an extra Autofinger instance" do
         expect(Autofinger.where("interest = ? AND owner = ?", interest.id, @account.id).count).to eq 1
+      end
+      it 'sets correct flash message' do
+        expect(flash[:notice]).to eq 'User is now on your autoread list with priority level of 3.'
+      end
+    end
+
+    context 'logged in user removes plan from autoread list' do
+      before do
+        @request.env['HTTP_REFERER'] = "/plans/#{interest.username}" #so redirect_to :back doesn't break
+        Autofinger.create(owner: @account, interest: interest, priority: 2)
+        post :set_autofinger_subscription, id: interest.username, priority: 0
+      end
+      it 'sets correct autoread priority' do
+        expect(@account.interests_in_others.find_by_interest(interest.id).priority).to eq 0
+      end
+      it "doesn't create an extra Autofinger instance" do
+        expect(Autofinger.where("interest = ? AND owner = ?", interest.id, @account.id).count).to eq 1
+      end
+      it 'sets correct flash message' do
+        expect(flash[:notice]).to eq 'User was removed from your autoread list.'
       end
     end
   end

--- a/spec/controllers/plans_controller_spec.rb
+++ b/spec/controllers/plans_controller_spec.rb
@@ -74,6 +74,7 @@ describe PlansController do
         @request.env['HTTP_REFERER'] = "/plans/#{interest.username}" #so redirect_to :back doesn't break
         post :set_autofinger_subscription, id: interest.username, priority: 1
       end
+
       it 'sets correct autoread priority' do
         expect(@account.interests_in_others.find_by_interest(interest.id).priority).to eq 1
       end
@@ -115,6 +116,15 @@ describe PlansController do
         end
       end
 
+      context 'assigns an invalid priority' do
+        let(:new_priority) { 4 }
+        it "doesn't change autoread priority" do
+          expect(@account.interests_in_others.find_by_interest(interest.id).priority).to eq 2
+        end
+        it 'sets correct flash message' do
+          expect(flash[:notice]).to eq 'Could not change autoread priority. If this happens more than once, contact the Plans admins at grinnellplans@gmail.com.'
+        end
+      end
     end
   end
 

--- a/spec/controllers/plans_controller_spec.rb
+++ b/spec/controllers/plans_controller_spec.rb
@@ -85,35 +85,36 @@ describe PlansController do
     context 'logged in user changes priority of existing autoread subject' do
       before do
         @request.env['HTTP_REFERER'] = "/plans/#{interest.username}" #so redirect_to :back doesn't break
-        Autofinger.create(owner: @account, interest: interest, priority: 2)
-        post :set_autofinger_subscription, id: interest.username, priority: 3
+        Autofinger.create(owner: @account.id, interest: interest.id, priority: 2)
+        post :set_autofinger_subscription, id: interest.username, priority: new_priority
       end
-      it 'sets correct autoread priority' do
-        expect(@account.interests_in_others.find_by_interest(interest.id).priority).to eq 3
-      end
-      it "doesn't create an extra Autofinger instance" do
-        expect(Autofinger.where("interest = ? AND owner = ?", interest.id, @account.id).count).to eq 1
-      end
-      it 'sets correct flash message' do
-        expect(flash[:notice]).to eq 'User is now on your autoread list with priority level of 3.'
-      end
-    end
 
-    context 'logged in user removes plan from autoread list' do
-      before do
-        @request.env['HTTP_REFERER'] = "/plans/#{interest.username}" #so redirect_to :back doesn't break
-        Autofinger.create(owner: @account, interest: interest, priority: 2)
-        post :set_autofinger_subscription, id: interest.username, priority: 0
+      context 'changes to different priority' do
+        let(:new_priority) { 3 }
+        it 'sets correct autoread priority' do
+          expect(@account.interests_in_others.find_by_interest(interest.id).priority).to eq 3
+        end
+        it "doesn't create an extra Autofinger instance" do
+          expect(Autofinger.where("interest = ? AND owner = ?", interest.id, @account.id).count).to eq 1
+        end
+        it 'sets correct flash message' do
+          expect(flash[:notice]).to eq 'User is now on your autoread list with priority level of 3.'
+        end
       end
-      it 'sets correct autoread priority' do
-        expect(@account.interests_in_others.find_by_interest(interest.id).priority).to eq 0
+
+      context 'removes plan from autoread list' do
+        let(:new_priority) { 0 }
+        it 'sets correct autoread priority' do
+          expect(@account.interests_in_others.find_by_interest(interest.id).priority).to eq 0
+        end
+        it "doesn't create an extra Autofinger instance" do
+          expect(Autofinger.where("interest = ? AND owner = ?", interest.id, @account.id).count).to eq 1
+        end
+        it 'sets correct flash message' do
+          expect(flash[:notice]).to eq 'User was removed from your autoread list.'
+        end
       end
-      it "doesn't create an extra Autofinger instance" do
-        expect(Autofinger.where("interest = ? AND owner = ?", interest.id, @account.id).count).to eq 1
-      end
-      it 'sets correct flash message' do
-        expect(flash[:notice]).to eq 'User was removed from your autoread list.'
-      end
+
     end
   end
 

--- a/spec/models/autofinger_spec.rb
+++ b/spec/models/autofinger_spec.rb
@@ -20,6 +20,19 @@ describe Autofinger do
       subject.exists?(@not_updated.id).should be_false
     end
   end
+
+  describe 'priority validation' do
+    it 'accepts priority 0' do
+      expect(FactoryGirl.build :autofinger, priority: 0).to be_valid
+    end
+    it 'accepts priority 3' do
+      expect(FactoryGirl.build :autofinger, priority: 3).to be_valid
+    end
+
+    it 'rejects priority > 3' do
+      expect(FactoryGirl.build :autofinger, priority: 4).not_to be_valid
+    end
+  end
 end
 
 # == Schema Information


### PR DESCRIPTION
This PR adds the radio buttons at the bottom of each plan so a user can add the plan they're reading to their autoread list (or remove it, or change their subscription). Issue #16.
I tried to maintain the same feel and functionality that's on grinnellplans.com now, but I didn't add any styling, so sometimes it looks funny (e.g. too high on the page, etc). 

I've done some opinionated things here, so please let me know if this isn't how we do things. For instance, I:
 - removed commented instructions from `config/routes.rb`. They're unnecessary, yes? I could add a link to [RoR guides](http://guides.rubyonrails.org/routing.html) if we want to be more beginner-friendly.
 - use `expect` syntax in tests
 - moved `flash[:notice]` to the application layout, so we don't have to include it in every individual view template.
 - decided that autoread level 0 is the same as not having a plan on autoread. That seems to make sense with the code that's there, but I'd love to be double-checked.